### PR TITLE
Find widget search history per editor instance

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1658,7 +1658,7 @@ export interface IEditorFindOptions {
 	/**
 	 * Controls how the find widget search history should be stored
 	 */
-	findSearchHistory?: 'never' | 'workspace';
+	findSearchHistory?: 'never' | 'workspace' | 'editor';
 }
 
 /**
@@ -1726,11 +1726,12 @@ class EditorFind extends BaseEditorOption<EditorOption.find, IEditorFindOptions,
 				},
 				'editor.find.findSearchHistory': {
 					type: 'string',
-					enum: ['never', 'workspace'],
+					enum: ['never', 'workspace', 'editor'],
 					default: defaults.findSearchHistory,
 					enumDescriptions: [
 						nls.localize('editor.find.findSearchHistory.never', 'Do not store search history from the find widget.'),
 						nls.localize('editor.find.findSearchHistory.workspace', 'Store search history across the active workspace'),
+						nls.localize('editor.find.findSearchHistory.editor', 'Store the search history per editor instance'),
 					],
 					description: nls.localize('find.findSearchHistory', "Controls how the find widget search history should be stored")
 				}
@@ -1754,7 +1755,7 @@ class EditorFind extends BaseEditorOption<EditorOption.find, IEditorFindOptions,
 			globalFindClipboard: boolean(input.globalFindClipboard, this.defaultValue.globalFindClipboard),
 			addExtraSpaceOnTop: boolean(input.addExtraSpaceOnTop, this.defaultValue.addExtraSpaceOnTop),
 			loop: boolean(input.loop, this.defaultValue.loop),
-			findSearchHistory: stringSet<'never' | 'workspace'>(input.findSearchHistory, this.defaultValue.findSearchHistory, ['never', 'workspace']),
+			findSearchHistory: stringSet<'never' | 'workspace' | 'editor'>(input.findSearchHistory, this.defaultValue.findSearchHistory, ['never', 'workspace', 'editor']),
 		};
 	}
 }

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -186,7 +186,11 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		this._contextKeyService = contextKeyService;
 		this._storageService = storageService;
 		this._notificationService = notificationService;
-		this._findWidgetSearchHistory = new FindWidgetSearchHistory(this._storageService);
+		const findSearchHistoryConfig = this._codeEditor.getOption(EditorOption.find).findSearchHistory;
+		this._findWidgetSearchHistory = new FindWidgetSearchHistory(
+			this._storageService,
+			findSearchHistoryConfig === 'editor' ? this._codeEditor : undefined
+		);
 
 		this._ctrlEnterReplaceAllWarningPrompted = !!storageService.getBoolean(ctrlEnterReplaceAllWarningPromptedKey, StorageScope.PROFILE);
 
@@ -970,7 +974,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			showHistoryHint: () => showHistoryKeybindingHint(this._keybindingService),
 			inputBoxStyles: defaultInputBoxStyles,
 			toggleStyles: defaultToggleStyles,
-			history: findSearchHistoryConfig === 'workspace' ? this._findWidgetSearchHistory : new Set([]),
+			history: findSearchHistoryConfig === 'never' ? new Set([]) : this._findWidgetSearchHistory,
 		}, this._contextKeyService));
 		this._findInput.setRegex(!!this._state.isRegex);
 		this._findInput.setCaseSensitive(!!this._state.matchCase);

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4064,7 +4064,7 @@ declare namespace monaco.editor {
 		/**
 		 * Controls how the find widget search history should be stored
 		 */
-		findSearchHistory?: 'never' | 'workspace';
+		findSearchHistory?: 'never' | 'workspace' | 'editor';
 	}
 
 	export type GoToLocationValues = 'peek' | 'gotoAndPeek' | 'goto';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Second iteration of the find widget persistent search history.
This PR adds a new option to save the history per editor instance as opposed to the whole workspace.
